### PR TITLE
Fix invalid &->&mut transmute

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ pub unsafe fn slice_to_array_unchecked<T, const N: usize>(source: &[T]) -> &[T; 
 
 /// Turn a mutable slice into a mutable reference to an array without bounds checking.
 pub unsafe fn slice_to_array_mut_unchecked<T, const N: usize>(source: &mut [T]) -> &mut [T; N] {
-    &mut *(source.as_ptr() as *mut [T; N])
+    &mut *(source.as_mut_ptr().cast::<[T; N]>())
 }
 
 /// Turns a slice into a reference to an array and a slice starting from the end of the array


### PR DESCRIPTION
https://github.com/LLBlumire/arrutil/blob/1df3cf12f600e8692d6b51d3fd36f90a921c754e/src/lib.rs#L33


This line is UB. `as_ptr()` creates a readonly pointer from `&&mut [T]` but is then converted to a `&mut [T; N]`.

```
error: Undefined Behavior: trying to reborrow <192836> for Unique permission at alloc82698[0xc], but that tag only grants SharedReadOnly permission for this location
   --> src/lib.rs:33:5
    |
33  |     &mut *(source.as_ptr() as *mut [T; N])
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |     |
    |     trying to reborrow <192836> for Unique permission at alloc82698[0xc], but that tag only grants SharedReadOnly permission for this location
    |     this error occurs as part of a reborrow at alloc82698[0xc..0x1c]
```
